### PR TITLE
Topic/#26-kawazoe

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,10 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
+$common_text_color: rgb(171, 178, 186);
+$main_color: rgb(40, 44, 52);
+
 #app {
   font-family: 'Helvetica Neue', 'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3', Meiryo, メイリオ, Osaka, 'MS PGothic', arial, helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -21,9 +24,28 @@ html,
 body {
   height: 100%;
   padding-bottom: 50px;
+  color: $common_text_color;
+  background-color: $main_color;
 }
 
 .full-height {
   height: 100%;
+}
+
+h1, h2, h3, h4, h5 {
+  font-weight: normal;
+  color: white !important;
+}
+
+hr {
+  color: rgb(75, 83, 98);
+}
+
+textarea {
+  padding: 2px 10px;
+  background-color: inherit;
+  &:focus {
+    outline-style: none;
+  }
 }
 </style>

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -43,11 +43,11 @@
   }
 
   .result-html {
-    padding:2px 10px;
+    padding: 2px 10px;
     overflow: auto;
-    background-color: #fff;
-    border:1px solid #ccc;
-    border-radius:4px
+    border: 1px solid rgb(153, 153, 153);
+    border-radius:4px;
+    background-color: inherit;
   }
 }
 

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -12,7 +12,7 @@ module.exports = {
       .url(devServer)
       .waitForElementVisible('#app', 5000)
       .assert.elementPresent('.editor')
-      .assert.containsText('textarea', 'Editor')
+      .assert.containsText('.page-title', 'Markdown Editor')
       .assert.elementCount('textarea', 1)
       .end()
   }

--- a/test/unit/specs/Editor.spec.js
+++ b/test/unit/specs/Editor.spec.js
@@ -5,7 +5,7 @@ describe('Editor.vue', () => {
   it('should render correct contents', () => {
     const Constructor = Vue.extend(Editor)
     const vm = new Constructor().$mount()
-    expect(vm.$el.querySelector('.editor textarea').textContent)
-      .to.equal('Editor')
+    expect(vm.$el.querySelector('.page-title p').textContent)
+      .to.equal('Markdown Editor')
   })
 })


### PR DESCRIPTION
### 関連
#26 

### 概要
* [共通] スタイルの適用

### 検証

SS
<img width="1172" alt="2017-11-25 11 00 25" src="https://user-images.githubusercontent.com/4644540/33226406-f34f4060-d1cf-11e7-9940-67df0309cecd.png">

unit testログ

    Editor.vue
        ✓ should render correct contents

    PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 1 of 1 SUCCESS (0.044 secs / 0.027 secs)

e2e testログ

    Running:  default e2e tests
    ✔ Element <#app> was visible after 74 milliseconds.
    ✔ Testing if element <.editor> is present.
    ✔ Testing if element <.page-title> contains text: "Markdown Editor".
    ✔ Testing if element <textarea> has count: 1

    OK. 4 assertions passed. (3.57s)